### PR TITLE
feat(fastly): use edge dictionaries for dynamic redirects

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -19,7 +19,7 @@ describe('Integration Test #online', () => {
     const res = await updateredirects({
       owner: 'trieloff',
       repo: 'helix-demo',
-      ref: 'c114364cda92f6b2441aacec2111fd093723b76f',
+      ref: '08444b97e204bee84aca9d07014f24d1be770af7',
       service: process.env.FASTLY_SERVICE_ID,
       token: process.env.HLX_FASTLY_AUTH,
       version: process.env.FASTLY_VERSION,


### PR DESCRIPTION
we continue to create one condition and header for each regular line in the redirects config, but dynamic redirects that are based on spreadsheet data will be handled differently. Each spreadsheet is turned into two edge dictionaries, one for permanent and one for temporary redirects. Then two conditions and headers are created that perform the dictionary lookup. This brings the overall number of conditions down to managable levels, even for large redirect tables.
